### PR TITLE
Add basic lifecycle hooks

### DIFF
--- a/examples/random_cocktail/index.rb
+++ b/examples/random_cocktail/index.rb
@@ -75,6 +75,10 @@ random_cocktail = RubyWasmUi.define_component(
         })
       end.transfer
     }
+  },
+
+  on_mounted: ->(component) {
+    component.fetch_cocktail
   }
 )
 

--- a/examples/todos/index.html
+++ b/examples/todos/index.html
@@ -15,6 +15,7 @@
         : "https://unpkg.com/ruby-wasm-ui@latest";
       document.head.appendChild(script);
     </script>
+    <script defer type="text/ruby" src="todos_repository.rb"></script>
     <script defer type="text/ruby" src="index.rb"></script>
 
     <title>Todos</title>

--- a/examples/todos/index.rb
+++ b/examples/todos/index.rb
@@ -13,6 +13,10 @@ AppComponent = RubyWasmUi.define_component(
     }
   },
 
+  on_mounted: ->(component) {
+    component.update_state(todos: TodosRepository.read_todos)
+  },
+
   # Render the complete application
   render: ->(component) {
     state = component.state
@@ -42,6 +46,7 @@ AppComponent = RubyWasmUi.define_component(
       todo = { id: rand(10000), text: text }
       state = self.state
       self.update_state(todos: state[:todos] + [todo])
+      TodosRepository.write_todos(state[:todos] + [todo])
     },
 
     # Remove a TODO from the list
@@ -51,6 +56,7 @@ AppComponent = RubyWasmUi.define_component(
       new_todos = state[:todos].dup
       new_todos.delete_at(new_todos.index { |todo| todo[:id] == id })
       self.update_state(todos: new_todos)
+      TodosRepository.write_todos(new_todos)
     },
 
     # Edit an existing TODO
@@ -62,6 +68,7 @@ AppComponent = RubyWasmUi.define_component(
       new_todos = state[:todos].dup
       new_todos[new_todos.index { |todo| todo[:id] == id }] = new_todos[new_todos.index { |todo| todo[:id] == id }].merge(text: edited)
       self.update_state(todos: new_todos)
+      TodosRepository.write_todos(new_todos)
     }
   }
 )

--- a/examples/todos/todos_repository.rb
+++ b/examples/todos/todos_repository.rb
@@ -1,0 +1,23 @@
+require "json"
+
+# Repository class for managing todos in local storage
+class TodosRepository
+  class << self
+    # Read todos from local storage
+    # @return [Array] Array of todo items
+    def read_todos
+      todos_json = JS.global[:localStorage].getItem('todos') || '[]'
+      JSON.parse(todos_json.to_s).map do |todo|
+        { id: todo["id"], text: todo["text"] }
+      end
+    end
+
+    # Write todos to local storage
+    # @param todos [Array] Array of todo items to be stored
+    # @return [void]
+    def write_todos(todos)
+      todos_json = JSON.generate(todos)
+      JS.global[:localStorage].setItem('todos', todos_json)
+    end
+  end
+end

--- a/packages/npm-packages/runtime/spec/ruby_wasm_ui/dom/scheduler_spec.rb
+++ b/packages/npm-packages/runtime/spec/ruby_wasm_ui/dom/scheduler_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe RubyWasmUi::Dom::Scheduler do
+  let(:mock_job) { -> { 'job executed' } }
+  let(:js) { class_double('JS').as_stubbed_const }
+  let(:global) { double('JS.global') }
+
+  before do
+    allow(js).to receive(:global).and_return(global)
+    allow(global).to receive(:queueMicrotask)
+    described_class.initialize_scheduler
+  end
+
+  describe '.initialize_scheduler' do
+    it 'initializes the scheduler with empty jobs and scheduled false' do
+      expect(described_class.jobs).to eq([])
+      expect(described_class.scheduled).to be false
+    end
+  end
+
+  describe '.enqueue_job' do
+    context 'when jobs is nil' do
+      before do
+        described_class.jobs = nil
+      end
+
+      it 'initializes scheduler and enqueues the job' do
+        described_class.enqueue_job(mock_job)
+        expect(described_class.jobs).to eq([mock_job])
+      end
+    end
+
+    context 'when jobs is already initialized' do
+      it 'enqueues the job' do
+        described_class.enqueue_job(mock_job)
+        expect(described_class.jobs).to eq([mock_job])
+      end
+    end
+
+    it 'schedules an update' do
+      expect(global).to receive(:queueMicrotask)
+      described_class.enqueue_job(mock_job)
+    end
+  end
+
+  describe '.schedule_update' do
+    context 'when not already scheduled' do
+      before do
+        described_class.scheduled = false
+      end
+
+      it 'sets scheduled to true and queues microtask' do
+        expect(global).to receive(:queueMicrotask)
+        described_class.send(:schedule_update)
+        expect(described_class.scheduled).to be true
+      end
+    end
+
+    context 'when already scheduled' do
+      before do
+        described_class.scheduled = true
+      end
+
+      it 'does not queue microtask' do
+        expect(global).not_to receive(:queueMicrotask)
+        described_class.send(:schedule_update)
+      end
+    end
+  end
+
+  describe '.process_jobs' do
+    let(:job1) { spy('job1') }
+    let(:job2) { spy('job2') }
+
+    before do
+      described_class.jobs = [job1, job2]
+      described_class.scheduled = true
+    end
+
+    it 'processes all jobs in the queue' do
+      described_class.send(:process_jobs)
+      expect(job1).to have_received(:call)
+      expect(job2).to have_received(:call)
+    end
+
+    it 'empties the jobs queue' do
+      described_class.send(:process_jobs)
+      expect(described_class.jobs).to be_empty
+    end
+
+    it 'sets scheduled to false after processing' do
+      described_class.send(:process_jobs)
+      expect(described_class.scheduled).to be false
+    end
+  end
+end

--- a/packages/npm-packages/runtime/src/ruby_wasm_ui/component.rb
+++ b/packages/npm-packages/runtime/src/ruby_wasm_ui/component.rb
@@ -1,14 +1,20 @@
 module RubyWasmUi
 
+  def self.empty_proc
+    -> (component) { }
+  end
+
   # Define a new component class
   # @param render [Proc] The render function
   # @param state [Proc, nil] The state function
   # @param methods [Hash] Additional methods to add to the component
   # @return [Class] The new component class
-  def self.define_component(render:, state: nil, methods: {})
+  def self.define_component(render:, state: nil, on_mounted: empty_proc, on_unmounted: empty_proc, methods: {})
     Class.new(Component) do
       self.class_variable_set(:@@state, state)
       self.class_variable_set(:@@render, render)
+      self.class_variable_set(:@@on_mounted, on_mounted)
+      self.class_variable_set(:@@on_unmounted, on_unmounted)
 
       # Add methods to the component
       methods.each do |method_name, method_proc|
@@ -38,6 +44,14 @@ module RubyWasmUi
     end
 
     attr_reader :state, :props
+
+    def on_mounted
+      self.class.class_variable_get(:@@on_mounted).call(self)
+    end
+
+    def on_unmounted
+      self.class.class_variable_get(:@@on_unmounted).call(self)
+    end
 
     # Get VDOM elements
     # @return [Array<JS::Object>]

--- a/packages/npm-packages/runtime/src/ruby_wasm_ui/dom/destroy_dom.rb
+++ b/packages/npm-packages/runtime/src/ruby_wasm_ui/dom/destroy_dom.rb
@@ -56,6 +56,7 @@ module RubyWasmUi
       # @return [void]
       def self.remove_component_node(vdom)
         vdom.component.unmount
+        vdom.component.on_unmounted
       end
     end
   end

--- a/packages/npm-packages/runtime/src/ruby_wasm_ui/dom/destroy_dom.rb
+++ b/packages/npm-packages/runtime/src/ruby_wasm_ui/dom/destroy_dom.rb
@@ -56,7 +56,7 @@ module RubyWasmUi
       # @return [void]
       def self.remove_component_node(vdom)
         vdom.component.unmount
-        vdom.component.on_unmounted
+        RubyWasmUi::Dom::Scheduler.enqueue_job(-> { vdom.component.on_unmounted })
       end
     end
   end

--- a/packages/npm-packages/runtime/src/ruby_wasm_ui/dom/mount_dom.rb
+++ b/packages/npm-packages/runtime/src/ruby_wasm_ui/dom/mount_dom.rb
@@ -15,7 +15,7 @@ module RubyWasmUi
           create_fragment_nodes(vdom, parent_el, index, hostComponent)
         when RubyWasmUi::Vdom::DOM_TYPES[:COMPONENT]
           create_component_node(vdom, parent_el, index, hostComponent)
-          vdom.component.on_mounted
+          RubyWasmUi::Dom::Scheduler.enqueue_job(-> { vdom.component.on_mounted })
         else
           raise "Can't mount DOM of type: #{vdom.type}"
         end

--- a/packages/npm-packages/runtime/src/ruby_wasm_ui/dom/mount_dom.rb
+++ b/packages/npm-packages/runtime/src/ruby_wasm_ui/dom/mount_dom.rb
@@ -15,6 +15,7 @@ module RubyWasmUi
           create_fragment_nodes(vdom, parent_el, index, hostComponent)
         when RubyWasmUi::Vdom::DOM_TYPES[:COMPONENT]
           create_component_node(vdom, parent_el, index, hostComponent)
+          vdom.component.on_mounted
         else
           raise "Can't mount DOM of type: #{vdom.type}"
         end

--- a/packages/npm-packages/runtime/src/ruby_wasm_ui/dom/scheduler.rb
+++ b/packages/npm-packages/runtime/src/ruby_wasm_ui/dom/scheduler.rb
@@ -1,0 +1,51 @@
+module RubyWasmUi
+  module Dom
+    module Scheduler
+      class << self
+        # @return [Boolean] Flag indicating if a job processing is scheduled
+        attr_accessor :scheduled
+
+        # @return [Array] Array of jobs to be processed
+        attr_accessor :jobs
+
+        # Initialize class variables
+        def initialize_scheduler
+          @scheduled = false
+          @jobs = []
+        end
+
+        # Enqueues a job to be processed
+        # @param job [Proc] The job to be executed
+        # @return [void]
+        def enqueue_job(job)
+          initialize_scheduler if @jobs.nil?
+          @jobs.push(job)
+          schedule_update
+        end
+
+        private
+
+        # Schedules an update if not already scheduled
+        # @return [void]
+        def schedule_update
+          return if @scheduled
+
+          @scheduled = true
+          # Using JS.global to access queueMicrotask
+          JS.global.queueMicrotask(-> { process_jobs })
+        end
+
+        # Processes all jobs in the queue
+        # @return [void]
+        def process_jobs
+          while @jobs.any?
+            job = @jobs.shift
+            job.call
+          end
+
+          @scheduled = false
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Ref
https://github.com/t0yohei/hanami-fe-fwk/commit/9619d80be2a924340f95b794f7823a94849494a1

## Memo
Unlike the implementation in JavaScript, the implementation related to Promise has been omitted.
This is because the implementation of asynchronous processing in ruby_wasm_ui is intended to use Fiber, making it difficult to implement Promise.
